### PR TITLE
Fix generator database config always overwritten by defaults when using DSL 

### DIFF
--- a/src/main/kotlin/com/rohanprabhu/gradle/plugins/kdjooq/DslUtils.kt
+++ b/src/main/kotlin/com/rohanprabhu/gradle/plugins/kdjooq/DslUtils.kt
@@ -41,7 +41,7 @@ fun Jdbc.properties(configure: JdbcPropertiesOps.() -> Unit) = JdbcPropertiesOps
 fun generatorConfig(configure: Generator.() -> Unit) = Generator().apply(configure)
 fun Configuration.generator(configure: Generator.() -> Unit) {
     generatorConfig(configure).also {
-        it.database = Database()
+        it.database = it.database ?: Database()
         this.generator = it
     }
 }


### PR DESCRIPTION
Currently any user defined config inside the generator -> database dsl gets overwritten back to defaults. This PR only sets the database defaults if no user supplied config has been set.

