### PR TITLE
clean depends on cleanJooqSourcesTaskName only if attachToCompileJava

### DIFF
--- a/src/main/kotlin/com/rohanprabhu/gradle/plugins/kdjooq/KotlinDslJooqPlugin.kt
+++ b/src/main/kotlin/com/rohanprabhu/gradle/plugins/kdjooq/KotlinDslJooqPlugin.kt
@@ -30,7 +30,7 @@ open class KotlinDslJooqPluginExtension(
             jooqConfiguration = configuration
             taskClasspath = jooqGeneratorRuntime
         }.apply {
-            cleanGeneratedSources(project, this)
+            cleanGeneratedSources(project, this, this@KotlinDslJooqPluginExtension)
             configureSourceSet(project, this@KotlinDslJooqPluginExtension, configuration)
         }
 
@@ -97,9 +97,11 @@ class KotlinDslJooqPlugin : Plugin<Project> {
     }
 }
 
-private fun cleanGeneratedSources(project: Project, task: Task) {
+private fun cleanGeneratedSources(project: Project, task: Task, extension: KotlinDslJooqPluginExtension) {
     val cleanJooqSourcesTaskName = "clean" + task.name.capitalize()
-    project.tasks.getByName(BasePlugin.CLEAN_TASK_NAME).dependsOn(cleanJooqSourcesTaskName)
+    if (extension.attachToCompileJava) {
+        project.tasks.getByName(BasePlugin.CLEAN_TASK_NAME).dependsOn(cleanJooqSourcesTaskName)
+    }
     task.mustRunAfter(cleanJooqSourcesTaskName)
 }
 


### PR DESCRIPTION
Before this change, if you run "gradle clean build" with attachToCompileJava=false:
* cleanYourJooqTaskName runs and deletes all autogenerated JOOQ source files
* yourJooqTaskName will not run, since attachToCompileJava was false
* The build fails because none of the autogenerated JOOQ source files exist anymore.

Usecase:
attachToCompileJava=true lets us manually run JOOQ, rather than it running on every build.
Without this patch, you can't do a "gradle clean build" of just your application, since it wipes out JOOQ files and then they don't get rebuilt.

Workaround is that you must run "gradle clean yourJooqTaskName build" any time you want to do a clean build to avoid failures.

If someone wants to do a clean and regenerate just their JOOQ classes, they can run:
gradle cleanYourJooqTaskName yourJooqTaskName