### PR TITLE
Move Objects class to plugin's package to prevent classpath conflicts.

### DIFF
--- a/src/main/java/com/rohanprabhu/gradle/plugins/kdjooq/util/Objects.java
+++ b/src/main/java/com/rohanprabhu/gradle/plugins/kdjooq/util/Objects.java
@@ -20,7 +20,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  */
-package nu.studer.gradle.util;
+package com.rohanprabhu.gradle.plugins.kdjooq.util;
 
 import groovy.lang.Closure;
 

--- a/src/main/kotlin/com/rohanprabhu/gradle/plugins/kdjooq/JooqCodeGenerationTask.kt
+++ b/src/main/kotlin/com/rohanprabhu/gradle/plugins/kdjooq/JooqCodeGenerationTask.kt
@@ -1,6 +1,6 @@
 package com.rohanprabhu.gradle.plugins.kdjooq
 
-import nu.studer.gradle.util.Objects
+import com.rohanprabhu.gradle.plugins.kdjooq.util.Objects
 import org.gradle.api.Action
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.FileCollection


### PR DESCRIPTION
Users may have `gradle-jooq-plugin` on the build classpath for whatever reason, and it will cause this plugin to not work correctly if the APIs don't match up (they don't in the latest version of `gradle-jooq-plugin`). Even when forking a class, it's better to move into your own package.