### PR TITLE
Clarify attachToCompileJava has to be at top of block to take effect …

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,8 +261,10 @@ Do remember to use the correct name of the task depending on the configuration n
 Optionally, if you want to run the task manually, you can disable this default behavior by setting the variable `attachToCompileJava` to false:
 
     jooqGenerator {
-        attatchToCompileJava = false
+        attachToCompileJava = false
     }
+
+Make sure this is the first line in your `jooqGenerator` block as it only applies to configurations defined after it.
 
 ## Configuring the generator JVM
 


### PR DESCRIPTION
…since it's read immediately.

It might make sense to move the configuration code into `afterEvaluate` since these sort of ordering constraints aren't intuitive but this is an easier fix for now.