### PR TITLE
feat(): resolve JOOQ Constant by reflection to be able to work with any jooq version

### DIFF
--- a/src/main/kotlin/com/rohanprabhu/gradle/plugins/kdjooq/JooqCodeGenerationTask.kt
+++ b/src/main/kotlin/com/rohanprabhu/gradle/plugins/kdjooq/JooqCodeGenerationTask.kt
@@ -7,7 +7,6 @@ import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.*
 import org.gradle.process.ExecResult
 import org.gradle.process.JavaExecSpec
-import org.jooq.Constants
 import org.jooq.codegen.GenerationTool
 import org.jooq.meta.jaxb.Configuration
 import java.io.File
@@ -54,8 +53,12 @@ open class JooqCodeGenerationTask : DefaultTask() {
         project.file(jooqConfiguration.configuration.generator.target.directory)
 
     private fun writeConfigFile(file: File) {
+        val xsdCodegenVersion = Class.forName("org.jooq.Constants")
+                .getDeclaredField("XSD_CODEGEN")
+                .get(null)
+
         val schema = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI)
-            .newSchema(GenerationTool::class.java.getResource("/xsd/${Constants.XSD_CODEGEN}"))
+            .newSchema(GenerationTool::class.java.getResource("/xsd/${xsdCodegenVersion}"))
 
         val marshaller = JAXBContext.newInstance(Configuration::class.java).let {
             it.createMarshaller().apply { setSchema(schema) }


### PR DESCRIPTION
Due to static access in code, the version defined in the plugin was ALWAYS used by the plugin instead of relying on the version used by "user project". By using reflection, we can bypass this and access to the value defined in Jooq Constants without any conflict.

Closes #19 