### PR TITLE
fix(cache): provide a stable confighash caclculation between runs

### DIFF
--- a/src/main/kotlin/com/rohanprabhu/gradle/plugins/kdjooq/JooqCodeGenerationTask.kt
+++ b/src/main/kotlin/com/rohanprabhu/gradle/plugins/kdjooq/JooqCodeGenerationTask.kt
@@ -46,7 +46,7 @@ open class JooqCodeGenerationTask : DefaultTask() {
     }
 
     @Input
-    fun getConfigHash() : Int = Objects.deepHashCode(jooqConfiguration.configuration)
+    fun getConfigHash() : Int = jooqConfiguration.configuration.toString().hashCode()
 
     @OutputDirectory
     fun getOutputDirectory() : File =


### PR DESCRIPTION
Due to the inconsistency of hashcode on objects between run, if we use remote cache or different gradle daemon for building (for example in CI with different steps), the `configHash` computation wasn't equals for the same configuration. Here, we rely on `JOOQ` stability on toString() for configuration (and also on stability of @lukaseder 😉).

Closes https://github.com/rohanprabhu/kotlin-dsl-gradle-jooq-plugin/issues/24